### PR TITLE
[Enhancement] Add model revision pinning for reproducible training runs

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -87,6 +87,9 @@ per_device_eval_batch_size = 1
 # Copy and rename this section; set model, dataset, and hyperparameters.
 [profile:my-lora-run]
 model = gemma-3n-e2b-it
+# Optional: pin to a specific HuggingFace revision for reproducibility.
+# model_revision = abc123def456  # commit hash or git ref
+
 dataset = my-dataset
 train_split = train
 validation_split = validation

--- a/gemma_tuner/core/profile_config.py
+++ b/gemma_tuner/core/profile_config.py
@@ -168,6 +168,7 @@ class ProfileConfig:
     # ── CLI-injected keys (set after config load) ──
 
     model_name_or_path: Optional[str] = _UNSET  # type: ignore[assignment]
+    model_revision: Optional[str] = _UNSET  # type: ignore[assignment]
     split: Optional[str] = _UNSET  # type: ignore[assignment]
 
     # ── Wizard-only keys ──

--- a/gemma_tuner/models/gemma/base_model_loader.py
+++ b/gemma_tuner/models/gemma/base_model_loader.py
@@ -47,6 +47,7 @@ def load_base_model_for_gemma(
     family: GemmaFamily,
     torch_dtype: torch.dtype,
     attn_implementation: str,
+    revision: str | None = None,
 ) -> Any:
     """Load base weights using the Auto class that matches ``config.architectures``."""
     if family == GemmaFamily.GEMMA_4:
@@ -55,29 +56,36 @@ def load_base_model_for_gemma(
         apply_clippable_linear_patch()
 
     try:
-        config = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
+        config_kwargs = {"trust_remote_code": True}
+        if revision:
+            config_kwargs["revision"] = revision
+        config = AutoConfig.from_pretrained(model_id, **config_kwargs)
     except Exception as e:
         logger.warning(
             "Could not load AutoConfig for %s (%s); using AutoModelForCausalLM.",
             model_id,
             e,
         )
-        return AutoModelForCausalLM.from_pretrained(
-            model_id,
-            torch_dtype=torch_dtype,
-            attn_implementation=attn_implementation,
-            low_cpu_mem_usage=True,
-            trust_remote_code=True,
-        )
+        load_kwargs = {
+            "torch_dtype": torch_dtype,
+            "attn_implementation": attn_implementation,
+            "low_cpu_mem_usage": True,
+            "trust_remote_code": True,
+        }
+        if revision:
+            load_kwargs["revision"] = revision
+        return AutoModelForCausalLM.from_pretrained(model_id, **load_kwargs)
 
     if not config_is_multimodal_gemma_like(config):
-        return AutoModelForCausalLM.from_pretrained(
-            model_id,
-            torch_dtype=torch_dtype,
-            attn_implementation=attn_implementation,
-            low_cpu_mem_usage=True,
-            trust_remote_code=True,
-        )
+        load_kwargs = {
+            "torch_dtype": torch_dtype,
+            "attn_implementation": attn_implementation,
+            "low_cpu_mem_usage": True,
+            "trust_remote_code": True,
+        }
+        if revision:
+            load_kwargs["revision"] = revision
+        return AutoModelForCausalLM.from_pretrained(model_id, **load_kwargs)
 
     multimodal_lm: Any = None
     try:
@@ -95,13 +103,15 @@ def load_base_model_for_gemma(
     last_err: Optional[Exception] = None
     for loader_cls in loaders:
         try:
-            model = loader_cls.from_pretrained(
-                model_id,
-                torch_dtype=torch_dtype,
-                attn_implementation=attn_implementation,
-                low_cpu_mem_usage=True,
-                trust_remote_code=True,
-            )
+            load_kwargs = {
+                "torch_dtype": torch_dtype,
+                "attn_implementation": attn_implementation,
+                "low_cpu_mem_usage": True,
+                "trust_remote_code": True,
+            }
+            if revision:
+                load_kwargs["revision"] = revision
+            model = loader_cls.from_pretrained(model_id, **load_kwargs)
             logger.info("Loaded multimodal base model %s via %s", model_id, loader_cls.__name__)
             return model
         except Exception as e:

--- a/gemma_tuner/models/gemma/finetune.py
+++ b/gemma_tuner/models/gemma/finetune.py
@@ -409,11 +409,15 @@ def main(profile_config: "ProfileConfig", output_dir: str):
     profile_config["dtype"] = "bfloat16" if torch_dtype == torch.bfloat16 else "float32"
 
     logger.info(f"Loading base model: {model_id}")
+    model_revision = profile_config.get("model_revision")
+    if model_revision:
+        logger.info(f"Using pinned revision: {model_revision}")
     model = load_base_model_for_gemma(
         model_id,
         family=family,
         torch_dtype=torch_dtype,
         attn_implementation=attn_impl,
+        revision=model_revision,
     )
 
     # LoRA configuration

--- a/gemma_tuner/scripts/export.py
+++ b/gemma_tuner/scripts/export.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 _ADAPTER_CONFIG_FILENAME = "adapter_config.json"
 
 
-def export_model_dir(model_path_or_profile: str) -> str:
+def export_model_dir(model_path_or_profile: str, model_revision: str | None = None) -> str:
     """Export a trained Gemma model (full or LoRA adapter) to a SafeTensors directory.
 
     Auto-detects whether the source is a LoRA adapter directory or a full model
@@ -56,6 +56,7 @@ def export_model_dir(model_path_or_profile: str) -> str:
 
     Args:
         model_path_or_profile: Local directory path or HuggingFace model id.
+        model_revision: Optional specific model revision (commit hash) to load for reproducibility.
 
     Returns:
         str: Path to the exported model directory.
@@ -83,11 +84,14 @@ def export_model_dir(model_path_or_profile: str) -> str:
         logger.info("Loading base model: %s", base_model_id)
         family = gate_gemma_model(base_model_id, entrypoint="export")
 
+        if model_revision:
+            logger.info("Using pinned revision for export: %s", model_revision)
         base_model = load_base_model_for_gemma(
             base_model_id,
             family=family,
             torch_dtype=torch_dtype,
             attn_implementation="eager",
+            revision=model_revision,
         )
 
         # PeftModel loads the adapter weights on top of the base model, then
@@ -108,11 +112,14 @@ def export_model_dir(model_path_or_profile: str) -> str:
         # --- Full model path or HuggingFace Hub id ---
         logger.info("Loading full model: %s", model_path_or_profile)
         family = gate_gemma_model(str(model_path_or_profile), entrypoint="export")
+        if model_revision:
+            logger.info("Using pinned revision for export: %s", model_revision)
         model = load_base_model_for_gemma(
             str(model_path_or_profile),
             family=family,
             torch_dtype=torch_dtype,
             attn_implementation="eager",
+            revision=model_revision,
         )
         processor_source = model_path_or_profile
 
@@ -164,5 +171,11 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Export a model to HF/SafeTensors directory")
     parser.add_argument("model", help="Path or model id to export")
+    parser.add_argument(
+        "--revision",
+        dest="model_revision",
+        default=None,
+        help="Specific model revision (commit hash) to load for reproducible export",
+    )
     args = parser.parse_args()
-    export_model_dir(args.model)
+    export_model_dir(args.model, model_revision=args.model_revision)


### PR DESCRIPTION
## Summary
Support optional model revision (commit hash) pinning in configuration to ensure reproducible training runs. This prevents unexpected behavior when HuggingFace model repositories are updated.

**Closes #6**

## Changes
- Add `model_revision` field to ProfileConfig for optional revision pinning
- Add `revision` parameter to `load_base_model_for_gemma()` function
- Pass revision through all `from_pretrained()` calls for reproducibility
- Log when using pinned revision for visibility during training/export
- Add `--revision` CLI argument to export script for command-line use

## Testing
- ✅ Verified revision parameter flows through all model loading paths
- ✅ Backward compatible: omit model_revision for latest (previous behavior)
- ✅ Works for both training (finetune.py) and export (export.py)

## Usage
Add to your profile config:
```ini
[profile:my-run]
model = google/gemma-4-E4B-it
model_revision = abc123def456  # pin to specific commit hash
```

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Configuration field added to ProfileConfig
- [x] Documentation updated (config.ini.example)
- [x] Backward compatible (optional field, defaults to latest)
- [x] Issue referenced (closes #6)

## Backward Compatibility
Fully backward compatible. Omitting model_revision retains previous behavior of loading the latest version from HuggingFace Hub.
