### PR TITLE
[Fix] Three latent Gemma 4 on MPS crash/override bugs

### DIFF
--- a/gemma_tuner/models/gemma/gemma4_patches.py
+++ b/gemma_tuner/models/gemma/gemma4_patches.py
@@ -44,6 +44,32 @@ def apply_clippable_linear_patch() -> None:
                 self.register_buffer("output_min", torch.tensor(-float("inf")))
                 self.register_buffer("output_max", torch.tensor(float("inf")))
 
+        @property
+        def linear(self) -> "PatchedGemma4ClippableLinear":
+            # Compatibility shim: upstream ``transformers.models.gemma4.modeling_gemma4``
+            # reads ``self.ffw_layer_1.linear.weight.dtype`` (and similar patterns
+            # for ``linear_start`` / ``post`` in the audio / vision tower blocks)
+            # on the assumption that ``Gemma4ClippableLinear`` still wraps an
+            # inner ``self.linear = nn.Linear(...)`` submodule. After this patch
+            # the class IS an ``nn.Linear``, so that attribute access would
+            # ``AttributeError`` without this shim, aborting the forward pass:
+            #
+            #   File "transformers/models/gemma4/modeling_gemma4.py", line 392,
+            #     in forward
+            #     gradient_clipping = min(
+            #         self.gradient_clipping,
+            #         torch.finfo(self.ffw_layer_1.linear.weight.dtype).max,
+            #     )
+            #   AttributeError: 'PatchedGemma4ClippableLinear' object has no
+            #     attribute 'linear'
+            #
+            # Returning ``self`` makes ``self.linear.weight`` resolve to
+            # ``self.weight`` — same tensor, same dtype. Defined as a
+            # ``@property`` (not a submodule) so it is not registered in
+            # ``self._modules`` and does not create a self-referential entry in
+            # ``named_modules`` / state-dict iteration.
+            return self
+
         def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
             if self.use_clipped_linears:
                 hidden_states = torch.clamp(hidden_states, self.input_min, self.input_max)

--- a/gemma_tuner/utils/device.py
+++ b/gemma_tuner/utils/device.py
@@ -79,19 +79,42 @@ def apply_device_defaults(profile_config: ProfileConfig | dict[str, Any]) -> Non
     """
     Apply device-specific configuration defaults in-place.
 
-    Called by config loading after profile_config is assembled. Overrides dtype
-    and attn_implementation for MPS compatibility, and warns about unsupported
-    mixed-precision settings on Apple Silicon.
+    Called by config loading after profile_config is assembled. Fills in
+    MPS-friendly ``dtype`` and ``attn_implementation`` defaults *only when the
+    profile (or ``[group:*]`` inheritance) did not already set them*, and
+    warns about unsupported mixed-precision settings on Apple Silicon. The
+    function name is "...defaults" — it is not supposed to stomp explicit
+    caller choices, but historically it did both. Using ``setdefault`` here
+    makes the implementation match the documented contract.
     """
     device = get_device()
     if device.type == "mps":
-        if profile_config.get("dtype") != "float32":
-            logger.warning("Overriding dtype to 'float32' for MPS compatibility.")
+        # Respect an explicit profile/group value; only fill in a default
+        # when unset. ``dtype`` is still self-correcting downstream: Gemma
+        # finetune re-probes bfloat16 support on MPS and bumps the value
+        # back to ``bfloat16`` when available (see finetune.py's
+        # ``_test_mps_bfloat16_support`` + dtype reconciliation).
+        existing_dtype = profile_config.get("dtype")
+        if not existing_dtype:
+            logger.info("apply_device_defaults: defaulting dtype to 'float32' on MPS (unset in profile).")
             profile_config["dtype"] = "float32"
+        elif existing_dtype != "float32":
+            logger.info(
+                "apply_device_defaults: keeping explicit dtype=%r (not overriding on MPS).",
+                existing_dtype,
+            )
 
-        if profile_config.get("attn_implementation") != "eager":
-            logger.warning("Overriding attn_implementation to 'eager' for MPS compatibility.")
+        existing_attn = profile_config.get("attn_implementation")
+        if not existing_attn:
+            logger.info(
+                "apply_device_defaults: defaulting attn_implementation to 'eager' on MPS (unset in profile)."
+            )
             profile_config["attn_implementation"] = "eager"
+        elif existing_attn != "eager":
+            logger.info(
+                "apply_device_defaults: keeping explicit attn_implementation=%r (not overriding on MPS).",
+                existing_attn,
+            )
 
         if profile_config.get("gradient_checkpointing"):
             logger.warning(

--- a/tests/test_gemma4_patches.py
+++ b/tests/test_gemma4_patches.py
@@ -49,3 +49,38 @@ def test_apply_clippable_linear_patch_makes_gemma4_linear_subclass_of_nn_linear(
     assert issubclass(m.Gemma4ClippableLinear, nn.Linear)
     apply_clippable_linear_patch()
     assert issubclass(m.Gemma4ClippableLinear, nn.Linear)
+
+
+@pytest.mark.skipif(
+    _transformers_version() < Version("5.5.0"),
+    reason="Gemma 4 modeling module requires transformers>=5.5.0",
+)
+def test_patched_clippable_linear_has_linear_property_returning_self():
+    """Upstream ``modeling_gemma4`` reads ``self.ffw_layer_1.linear.weight.dtype``
+    (and similar patterns in ``lconv1d`` / ``self_attn.post``) on the assumption
+    that ``Gemma4ClippableLinear`` still wraps an inner ``nn.Linear``. Without
+    the compatibility shim the forward pass ``AttributeError``s. This test
+    pins the shim: ``linear`` must resolve to the module itself so that
+    ``module.linear.weight is module.weight``."""
+    from transformers.models.gemma4 import modeling_gemma4 as m
+
+    from gemma_tuner.models.gemma.gemma4_patches import apply_clippable_linear_patch
+
+    apply_clippable_linear_patch()
+
+    class _Cfg:
+        use_clipped_linears = False
+
+    mod = m.Gemma4ClippableLinear(_Cfg(), in_features=4, out_features=3)
+    # The shim makes ``mod.linear`` the module itself, so ``mod.linear.weight``
+    # is the *same* parameter tensor as ``mod.weight``.
+    assert mod.linear is mod
+    assert mod.linear.weight is mod.weight
+    assert mod.linear.weight.dtype == mod.weight.dtype
+
+    # The shim is a ``@property``, not a real submodule, so iterating
+    # ``named_modules`` must NOT yield a self-referential ``mod.linear`` entry
+    # (which would break state-dict round-tripping and any recursive module
+    # walk).
+    submodule_names = {name for name, _ in mod.named_modules()}
+    assert "linear" not in submodule_names

--- a/tools/eval_gemma_asr.py
+++ b/tools/eval_gemma_asr.py
@@ -17,6 +17,16 @@ Usage:
 
 from __future__ import annotations
 
+# IMPORTANT: bootstrap must import before torch so that
+# ``PYTORCH_MPS_HIGH_WATERMARK_RATIO`` and ``PYTORCH_MPS_LOW_WATERMARK_RATIO``
+# are both set (with ``low < high``) before the MPS allocator initialises.
+# Without this, PyTorch 2.11 on a fresh MPS environment can compute a
+# low-watermark ratio of ``1.4`` (greater than 1 = illegal) and abort
+# ``model.to("mps")`` with ``RuntimeError: invalid low watermark ratio 1.4``.
+# ``gemma_tuner/cli_typer.py`` imports bootstrap first for the same reason;
+# standalone tool scripts must do the same.
+import gemma_tuner.core.bootstrap  # noqa: F401  # side-effect: MPS env setup
+
 import argparse
 import csv
 import time


### PR DESCRIPTION
## Summary

Three independent hard-failure bugs that together block Gemma 4 multimodal runs on Apple Silicon. Each is a crash or a silent config revert, not a design preference, so all three land together as a single narrow fix.

Bundled because they are trivially reviewable on their own and the fixes are non-interacting — you can merge any subset if you prefer.

## Changes

### 1. `apply_device_defaults` stops stomping explicit profile values

`gemma_tuner/utils/device.py::apply_device_defaults` is documented as "Apply device-specific configuration **defaults** in-place" but was performing unconditional overrides on both `dtype` and `attn_implementation` for MPS, silently reverting any value the caller set in `[profile:*]` or `[group:*]`.

Switched to `setdefault`-style behavior: respect the explicit value, only fill in the MPS default when unset. Log both branches at INFO so the chosen value is visible in `run.log`. **Keeps `eager` / `float32` as the MPS defaults when nothing is set** — this PR does not relitigate the default itself, only the "don't silently revert explicit caller values" contract.

### 2. `tools/eval_gemma_asr.py` imports `gemma_tuner.core.bootstrap` before `torch`

Without it, PyTorch 2.11 on a fresh MPS environment aborts `model.to("mps")` with:

```
RuntimeError: invalid low watermark ratio 1.4
```

because `PYTORCH_MPS_LOW_WATERMARK_RATIO` was never set (only `HIGH_WATERMARK_RATIO` was), so the allocator computes a low-watermark greater than 1. `gemma_tuner/cli_typer.py` imports bootstrap first for exactly the same reason — standalone tool scripts must do the same. One-line side-effect import, same pattern.

### 3. `PatchedGemma4ClippableLinear` exposes a `@property linear` that returns `self`

Upstream `transformers.models.gemma4.modeling_gemma4` reads `self.ffw_layer_1.linear.weight.dtype` (and the same pattern for `linear_start` / `self_attn.post`) on the assumption that `Gemma4ClippableLinear` still wraps an inner `nn.Linear` submodule. `apply_clippable_linear_patch()` replaces it with an `nn.Linear` subclass that has no `.linear` attribute, so the upstream forward `AttributeError`s the first time it runs:

```
File "transformers/models/gemma4/modeling_gemma4.py", line 392, in forward
    gradient_clipping = min(
        self.gradient_clipping,
        torch.finfo(self.ffw_layer_1.linear.weight.dtype).max,
    )
AttributeError: 'PatchedGemma4ClippableLinear' object has no attribute 'linear'
```

Returning `self` makes `module.linear.weight is module.weight` — same tensor, same dtype, pure compatibility shim with no behavioral change. Defined as a `@property` rather than a real submodule so `named_modules()` does not yield a self-referential `linear` entry that would break state-dict iteration.

There are three callsites in upstream `modeling_gemma4.py` that read `.linear.weight` on a ClippableLinear (`self_attn.post`, `lconv1d.linear_start`, `ffw_layer_1`). The shim handles all three.

## Testing

- `pytest tests/test_gemma4_patches.py tests/test_family.py tests/test_bootstrap.py -v` — **16 passed, 0 failed**. New test `test_patched_clippable_linear_has_linear_property_returning_self` pins the shim's identity (`mod.linear is mod`), weight tensor identity (`mod.linear.weight is mod.weight`), and non-membership in `named_modules` (the `@property` must not appear as a submodule).
- Manual repro of each bug on M2 Max 64 GB + PyTorch 2.11 + transformers 5.5.0 + peft 0.18.1 + MPS, with `google/gemma-4-E4B-it` and Common Voice 25 Lithuanian:
  - Bug 1: before, `run.log` contains `Overriding attn_implementation to 'eager' for MPS compatibility` even when `[profile:*]` sets a different value. After, `run.log` contains `keeping explicit attn_implementation=... (not overriding on MPS)`.
  - Bug 2: before, `python tools/eval_gemma_asr.py ...` crashes at `model.to("mps")` with `invalid low watermark ratio 1.4`. After, the allocator initialises cleanly.
  - Bug 3: before, `generate()` on a patched model `AttributeError`s at `modeling_gemma4.py:392`. After, `generate()` runs the audio + text forward to completion.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Regression test added for the `linear` property shim
- [x] Existing tests still passing (`test_apply_clippable_linear_patch_makes_gemma4_linear_subclass_of_nn_linear`, `test_bootstrap_sets_mps_env`, all `test_family.py`)
- [x] Backward compatible (see below)

## Backward Compatibility

- **Fix 1**: existing profiles that explicitly set `attn_implementation = eager` or `dtype = float32` continue to get exactly those values. Profiles that leave these unset continue to get `eager` / `float32` on MPS (same as today). The only behavior change is: profiles that set `attn_implementation = sdpa` (or anything else) now keep that value instead of being silently reverted to `eager`. CUDA and CPU branches are untouched.
- **Fix 2**: adds one side-effect import at the top of `tools/eval_gemma_asr.py`. No CLI, argument, or semantic change. If you already had bootstrap in your environment via some other path, this is a no-op.
- **Fix 3**: pure additive shim — the patched class gains a `@property` that returns `self`. No existing attribute, method, or behavior is removed or changed. The shim only matters when upstream `modeling_gemma4` reads `<mod>.linear.<attr>`, which is a crash without this PR.

## Notes

- This PR intentionally does **not** change the MPS `attn_implementation` default from `eager` to `sdpa`. For Gemma 4 specifically, `eager` on MPS produces unrelated hallucinated output on the audio tower (same model, dtype, device, clip — only the backend differs), which is a separate, larger conversation. This PR just makes sure that if you set `sdpa` in your profile, the framework honors it.
- `README/guides/apple-silicon/gemma4-guide.md`'s "prefer eager on MPS" advice is a holdover from Gemma 3n; updating it is also out of scope here.