### PR TITLE
Audiovisual LoRA training support (supersedes #22)

### DIFF
--- a/README/Datasets.md
+++ b/README/Datasets.md
@@ -129,13 +129,35 @@ These keys can appear in `[DEFAULT]`, `[dataset:…]`, `[model:…]`, or `[profi
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `modality` | `audio` | `audio` — speech + transcript (current behavior). `text` — text-only CSV fine-tuning (instruction or completion). `image` — image + text CSV (captioning or VQA); see image columns below. |
+| `modality` | `audio` | `audio` — speech + transcript (current behavior). `text` — text-only CSV fine-tuning (instruction or completion). `image` — image + text CSV (captioning or VQA); see image columns below. `audiovisual` — joint audio + image + text in one sample (caption-style only); requires `audio_path` and the column named by `image_path_column` to be present in the CSV. |
 | `text_sub_mode` | `instruction` | When `modality = text`: `instruction` — prompt + response columns with prompt masked from loss; `completion` — single text column, full sequence trained. |
 | `prompt_column` | *(empty / none)* | When `text_sub_mode = instruction`, the column name for the user/prompt text. Ignored for `completion`. When `modality = image` and `image_sub_mode = vqa`, the column name for the **question** text. |
 | `max_seq_length` | `2048` | Maximum token length for text-mode batches (padding/truncation). |
 | `image_sub_mode` | `caption` | When `modality = image`: `caption` — fixed instruction + caption/response in `text_column`; `vqa` — question in `prompt_column`, answer in `text_column`. |
 | `image_path_column` | `image_path` | CSV column for the image file path (local or supported URI). |
 | `image_token_budget` | `280` | Vision token budget for the processor. Must be one of `70`, `140`, `280`, `560`, `1120` (train/serve must match). |
+
+### `modality = audiovisual` (joint image + audio + text)
+
+Single training run over rows that have *both* an `audio_path` and an image file (`image_path_column`, default `image_path`), with a free-form caption in `text_column`. The collator builds a fixed user prompt — "Describe what is happening using the attached audio and image." — and supervises on the row's caption.
+
+Constraints:
+
+- Caption-style only. `image_sub_mode = vqa` is rejected at config time for this modality.
+- Local CSV datasets only (same gate as `modality = image`).
+- `image_token_budget` applies as in image mode.
+
+Example profile:
+
+```ini
+[profile:my-audiovisual-lora]
+model = gemma-4-e2b-it
+dataset = my-av-dataset
+modality = audiovisual
+image_path_column = image_path
+text_column = label
+per_device_train_batch_size = 4
+```
 
 See `config/config.ini.example` for commented examples.
 

--- a/gemma_tuner/core/config.py
+++ b/gemma_tuner/core/config.py
@@ -671,6 +671,13 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
         conf["image_sub_mode"] = ism
         if modality_val in ("image", "audiovisual") and ism not in ("caption", "vqa"):
             raise ValueError(f"image_sub_mode must be 'caption' or 'vqa', got {ism!r}")
+        # audiovisual currently only supports caption-style instruction; VQA isn't wired in the collator.
+        if modality_val == "audiovisual" and ism == "vqa":
+            raise ValueError(
+                "modality=audiovisual does not support image_sub_mode=vqa yet "
+                "(audiovisual collator uses a fixed caption-style instruction). "
+                "Use image_sub_mode=caption."
+            )
     if "image_path_column" in conf:
         ipc = conf["image_path_column"]
         if ipc is None or (isinstance(ipc, str) and not str(ipc).strip()):
@@ -686,11 +693,11 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
                 f"image_token_budget must be one of {sorted(ConfigConstants.IMAGE_TOKEN_BUDGET_ALLOWED)}, got {itb_int}"
             )
         ims = str(conf.get("image_sub_mode", "caption")).strip().lower()
-        if ims == "vqa":
+        if ims == "vqa" and modality_val == "image":
             pc = conf.get("prompt_column")
             if pc is None or (isinstance(pc, str) and not str(pc).strip()):
                 raise ValueError(
-                    f"modality={modality_val} with image_sub_mode=vqa requires prompt_column (question column)"
+                    "modality=image with image_sub_mode=vqa requires prompt_column (question column)"
                 )
 
     # Validate data splits are specified

--- a/gemma_tuner/core/config.py
+++ b/gemma_tuner/core/config.py
@@ -645,8 +645,8 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
     if "modality" in conf and conf["modality"] is not None:
         modality = str(conf["modality"]).strip().lower()
         conf["modality"] = modality
-        if modality not in ("audio", "text", "image"):
-            raise ValueError(f"modality must be 'audio', 'text', or 'image', got {modality!r}")
+        if modality not in ("audio", "text", "image", "audiovisual"):
+            raise ValueError(f"modality must be 'audio', 'text', 'image', or 'audiovisual', got {modality!r}")
     if "text_sub_mode" in conf and conf["text_sub_mode"] is not None:
         sub = str(conf["text_sub_mode"]).strip().lower()
         conf["text_sub_mode"] = sub
@@ -664,12 +664,12 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
         if msl < 1:
             raise ValueError(f"max_seq_length must be >= 1, got {msl}")
 
-    # Image modality (defaults applied via FALLBACK_DEFAULTS; validation only when modality=image)
+    # Image-bearing modalities (defaults applied via FALLBACK_DEFAULTS; validation only when needed)
     modality_val = str(conf.get("modality", "audio")).strip().lower()
     if "image_sub_mode" in conf and conf["image_sub_mode"] is not None:
         ism = str(conf["image_sub_mode"]).strip().lower()
         conf["image_sub_mode"] = ism
-        if modality_val == "image" and ism not in ("caption", "vqa"):
+        if modality_val in ("image", "audiovisual") and ism not in ("caption", "vqa"):
             raise ValueError(f"image_sub_mode must be 'caption' or 'vqa', got {ism!r}")
     if "image_path_column" in conf:
         ipc = conf["image_path_column"]
@@ -677,7 +677,7 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
             conf["image_path_column"] = "image_path"
         elif isinstance(ipc, str):
             conf["image_path_column"] = ipc.strip()
-    if modality_val == "image":
+    if modality_val in ("image", "audiovisual"):
         itb = conf.get("image_token_budget", 280)
         itb_int = int(itb) if not isinstance(itb, int) else itb
         conf["image_token_budget"] = itb_int
@@ -689,7 +689,9 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
         if ims == "vqa":
             pc = conf.get("prompt_column")
             if pc is None or (isinstance(pc, str) and not str(pc).strip()):
-                raise ValueError("modality=image with image_sub_mode=vqa requires prompt_column (question column)")
+                raise ValueError(
+                    f"modality={modality_val} with image_sub_mode=vqa requires prompt_column (question column)"
+                )
 
     # Validate data splits are specified
     for split_key in ("train_split", "validation_split"):

--- a/gemma_tuner/models/common/collators.py
+++ b/gemma_tuner/models/common/collators.py
@@ -543,7 +543,18 @@ class DataCollatorGemmaImage(DataCollatorGemmaMultimodal):
 
 
 class DataCollatorGemmaAudioVisual(DataCollatorGemmaMultimodal):
-    """Batch audio+image+text examples for Gemma multimodal fine-tuning."""
+    """Batch audio+image+text examples for Gemma multimodal fine-tuning.
+
+    Caption-style only: a fixed instruction prompts the model to describe the audio+image
+    pair, and the row's ``text_column`` is the supervised response. VQA isn't supported
+    here yet — :func:`gemma_tuner.core.config._validate_profile_config` rejects
+    ``image_sub_mode=vqa`` for this modality at config time.
+
+    Uses :meth:`_labels_with_pad_and_prompt_mask_if_missing` (the audio-path label builder)
+    rather than the image-path variant: the Gemma audio-aware processor may set ``labels``
+    itself when ``audio=`` is passed, so we only rebuild when missing. The image-only path
+    never sets labels and always rebuilds.
+    """
 
     _INSTRUCTION = "Describe what is happening using the attached audio and image."
 

--- a/gemma_tuner/models/common/collators.py
+++ b/gemma_tuner/models/common/collators.py
@@ -534,9 +534,102 @@ class DataCollatorGemmaImage(DataCollatorGemmaMultimodal):
                 ]
             )
 
-        encoded = self._apply_chat_template_and_processor(messages_batch, images=images)
+        # Gemma4 processor expects batched images as "list per sample" when text is batched.
+        batched_images = [[img] for img in images]
+        encoded = self._apply_chat_template_and_processor(messages_batch, images=batched_images)
         self._inject_mm_token_types_and_validate_bos(encoded)
         self._labels_with_prompt_mask_and_attention_padding(encoded)
+        return encoded
+
+
+class DataCollatorGemmaAudioVisual(DataCollatorGemmaMultimodal):
+    """Batch audio+image+text examples for Gemma multimodal fine-tuning."""
+
+    _INSTRUCTION = "Describe what is happening using the attached audio and image."
+
+    def __init__(
+        self,
+        processor,
+        text_column: str,
+        *,
+        family: GemmaFamily,
+        image_path_column: str = "image_path",
+        sampling_rate_hint: Optional[int] = None,
+    ):
+        self.processor = processor
+        self.text_column = text_column
+        self.image_path_column = image_path_column
+        self.sampling_rate_hint = sampling_rate_hint
+        self._family = family
+        self._caps = family_capabilities(family)
+        self._warned_prompt_masking: List[bool] = [False]
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, torch.Tensor]:
+        from gemma_tuner.utils.dataset_prep import load_audio_local_or_gcs
+
+        audios: List[List[float]] = []
+        images: List[Any] = []
+        messages_batch: List[Any] = []
+
+        sampling_rate = resolve_processor_sampling_rate(self.processor, hint=self.sampling_rate_hint)
+
+        for ex in features:
+            row_id = ex.get("id", ex.get("note_id", "<unknown>"))
+
+            audio_path = ex.get("audio_path", ex.get("audio"))
+            if _is_null(audio_path):
+                raise KeyError(
+                    "DataCollatorGemmaAudioVisual: no audio path found in sample. "
+                    f"Expected 'audio_path' or 'audio' key. Available keys: {list(ex.keys())}"
+                )
+            audio = load_audio_local_or_gcs(audio_path, sampling_rate=sampling_rate)
+            audios.append(audio)
+
+            image_path = ex.get(self.image_path_column)
+            if _is_null(image_path):
+                raise KeyError(
+                    f"DataCollatorGemmaAudioVisual: image path column {self.image_path_column!r} missing or null. "
+                    f"Keys: {list(ex.keys())}"
+                )
+            try:
+                img = _load_image_as_rgb(image_path)
+            except Exception as e:
+                raise RuntimeError(f"DataCollatorGemmaAudioVisual: row id={row_id!r}: {e}") from e
+            images.append(img)
+
+            text_val = ex.get(self.text_column)
+            if self.text_column not in ex:
+                raise KeyError(
+                    f"DataCollatorGemmaAudioVisual: text column {self.text_column!r} missing. Keys: {list(ex.keys())}"
+                )
+            if _is_null(text_val):
+                raise ValueError(
+                    f"DataCollatorGemmaAudioVisual: text column {self.text_column!r} has a null value "
+                    f"(row id={row_id!r})"
+                )
+
+            messages_batch.append(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "image", "image": img},
+                            {"type": "audio", "audio": "<audio:attached>"},
+                            {"type": "text", "text": self._INSTRUCTION},
+                        ],
+                    },
+                    {"role": "assistant", "content": [{"type": "text", "text": str(text_val)}]},
+                ]
+            )
+
+        encoded = self._apply_chat_template_and_processor(
+            messages_batch,
+            images=[[img] for img in images],
+            audio=audios,
+            sampling_rate=sampling_rate,
+        )
+        self._inject_mm_token_types_and_validate_bos(encoded)
+        self._labels_with_pad_and_prompt_mask_if_missing(encoded)
         return encoded
 
 

--- a/gemma_tuner/models/gemma/finetune.py
+++ b/gemma_tuner/models/gemma/finetune.py
@@ -77,6 +77,7 @@ from transformers.utils import logging as hf_logging
 
 from gemma_tuner.models.common.collators import (
     DataCollatorGemmaAudio,
+    DataCollatorGemmaAudioVisual,
     DataCollatorGemmaImage,
     DataCollatorGemmaText,
     apply_image_token_budget_to_processor,
@@ -338,7 +339,7 @@ def main(profile_config: "ProfileConfig", output_dir: str):
     }
     if prompt_column is not None:
         dataset_config["prompt_column"] = prompt_column
-    if modality == "image":
+    if modality in ("image", "audiovisual"):
         dataset_config["image_sub_mode"] = str(profile_config.get("image_sub_mode", "caption")).strip().lower()
         ipc = profile_config.get("image_path_column")
         if ipc:
@@ -363,7 +364,7 @@ def main(profile_config: "ProfileConfig", output_dir: str):
             logger.warning(f"Failed to load validation split; running without eval: {e}")
 
     image_path_column_resolved = str(profile_config.get("image_path_column") or "image_path").strip() or "image_path"
-    if modality == "image":
+    if modality in ("image", "audiovisual"):
         dataset_dir = resolve_data_datasets_dir(dataset_name)
 
         def _resolve_image_paths(batch: dict) -> dict:
@@ -404,7 +405,7 @@ def main(profile_config: "ProfileConfig", output_dir: str):
     else:
         logger.info(f"Loading processor ({modality} modality): {model_id}")
         processor = AutoProcessor.from_pretrained(model_id, revision=model_revision)
-        if modality == "image":
+        if modality in ("image", "audiovisual"):
             _itb = int(profile_config.get("image_token_budget", 280))
             apply_image_token_budget_to_processor(processor, _itb)
 
@@ -570,6 +571,15 @@ def main(profile_config: "ProfileConfig", output_dir: str):
             prompt_column=prompt_column,
             image_token_budget=image_token_budget,
             sub_mode=image_sub_mode,
+        )
+    elif modality == "audiovisual":
+        image_path_col = str(profile_config.get("image_path_column") or "image_path").strip() or "image_path"
+        data_collator = DataCollatorGemmaAudioVisual(
+            processor=processor,
+            text_column=text_column,
+            family=family,
+            image_path_column=image_path_col,
+            sampling_rate_hint=None,
         )
     else:
         data_collator = DataCollatorGemmaAudio(

--- a/gemma_tuner/utils/dataset_utils.py
+++ b/gemma_tuner/utils/dataset_utils.py
@@ -305,6 +305,7 @@ def load_dataset_split(split, dataset_config, max_samples=None, patches_dir="dat
     )
     _ensure_modality_local_csv_only(context, adapter, streaming_enabled, "text")
     _ensure_modality_local_csv_only(context, adapter, streaming_enabled, "image")
+    _ensure_modality_local_csv_only(context, adapter, streaming_enabled, "audiovisual")
     source = adapter.patch_source(context)
 
     # Debug information for troubleshooting data loading issues
@@ -351,6 +352,10 @@ def load_dataset_split(split, dataset_config, max_samples=None, patches_dir="dat
                     "modality=image with image_sub_mode=vqa requires prompt_column in dataset_config (profile)."
                 )
             required_columns.add(context.prompt_column)
+    if context.modality == "audiovisual":
+        required_columns.add("audio_path")
+        ipc = context.image_path_column.strip() if context.image_path_column else "image_path"
+        required_columns.add(ipc)
 
     def _validate_columns(columns: Iterable[str]):
         missing = [c for c in required_columns if c not in columns]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,8 +210,10 @@ def test_validate_audiovisual_modality_profile():
     }
     _validate_profile_config(dict(base), ConfigConstants.REQUIRED_PROFILE_KEYS)
 
-    with pytest.raises(ValueError, match=r"prompt_column"):
-        bad = {**base, "image_sub_mode": "vqa"}
+    # audiovisual must reject vqa: the collator hardcodes a caption-style instruction
+    # and ignores prompt_column. Fail loud at config time instead of silently captioning.
+    with pytest.raises(ValueError, match=r"audiovisual.*does not support image_sub_mode=vqa"):
+        bad = {**base, "image_sub_mode": "vqa", "prompt_column": "question"}
         _validate_profile_config(bad, ConfigConstants.REQUIRED_PROFILE_KEYS)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -188,6 +188,33 @@ def test_validate_image_modality_profile():
         _validate_profile_config(vqa_no_prompt, ConfigConstants.REQUIRED_PROFILE_KEYS)
 
 
+def test_validate_audiovisual_modality_profile():
+    base = {
+        "model": "gemma-4-e2b-it",
+        "dataset": "dummy",
+        "base_model": "google/gemma-4-E2B-it",
+        "train_split": "train",
+        "validation_split": "validation",
+        "text_column": "text",
+        "max_label_length": 128,
+        "max_duration": 30.0,
+        "per_device_train_batch_size": 1,
+        "num_train_epochs": 1,
+        "logging_steps": 1,
+        "save_steps": 50,
+        "save_total_limit": 1,
+        "gradient_accumulation_steps": 1,
+        "modality": "audiovisual",
+        "image_sub_mode": "caption",
+        "image_token_budget": 280,
+    }
+    _validate_profile_config(dict(base), ConfigConstants.REQUIRED_PROFILE_KEYS)
+
+    with pytest.raises(ValueError, match=r"prompt_column"):
+        bad = {**base, "image_sub_mode": "vqa"}
+        _validate_profile_config(bad, ConfigConstants.REQUIRED_PROFILE_KEYS)
+
+
 def test_load_profile_config_missing_profile_raises():
     """
     Tests that loading non-existent profiles raises appropriate ValueError exceptions.

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -423,6 +423,48 @@ max_duration = 30
         _du_mod._config = None
 
 
+def test_audiovisual_modality_loads_local_csv(tmp_path):
+    data_dir = tmp_path / "data" / "datasets" / "av-toy"
+    os.makedirs(data_dir, exist_ok=True)
+    _write_csv(
+        str(data_dir / "train.csv"),
+        [{"id": 1, "audio_path": "a.wav", "image_path": "x.png", "text": "scene: people talking in a kitchen"}],
+    )
+    cfg_path = tmp_path / "config.ini"
+    cfg_path.write_text("""
+[dataset:av-toy]
+source = av-src
+text_column = text
+train_split = train
+validation_split = validation
+max_label_length = 64
+max_duration = 30
+""")
+
+    cwd = os.getcwd()
+    _du_mod._config = None
+    try:
+        os.chdir(str(tmp_path))
+        ds, source = load_dataset_split(
+            split="train",
+            dataset_config={
+                "name": "av-toy",
+                "text_column": "text",
+                "modality": "audiovisual",
+                "image_path_column": "image_path",
+            },
+            streaming_enabled=False,
+        )
+    finally:
+        os.chdir(cwd)
+        _du_mod._config = None
+
+    assert source == "av-src"
+    assert len(ds) == 1
+    assert ds[0]["audio_path"] == "a.wav"
+    assert ds[0]["image_path"] == "x.png"
+
+
 def test_text_modality_rejects_granary_adapter(tmp_path):
     data_dir = tmp_path / "data" / "datasets" / "granary-en"
     os.makedirs(data_dir, exist_ok=True)

--- a/tests/test_gemma_collator.py
+++ b/tests/test_gemma_collator.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from PIL import Image as PILImage
 
@@ -94,9 +95,18 @@ def test_audio_collator_gemma4_injects_mm_token_type_ids():
 
 
 class DummyAudioVisualProcessor(DummyProcessor):
+    def __init__(self):
+        super().__init__()
+        self.last_audio = None
+        self.last_images = None
+        self.last_text = None
+
     def __call__(self, text=None, audio=None, images=None, return_tensors=None, padding=None, **kwargs):
         if audio is None or images is None:
             raise ValueError("expected both audio and images")
+        self.last_audio = audio
+        self.last_images = images
+        self.last_text = text
         return super().__call__(text=text, return_tensors=return_tensors, padding=padding, **kwargs)
 
 
@@ -124,3 +134,60 @@ def test_audiovisual_collator_produces_labels_and_ids(tmp_path):
     assert "token_type_ids" in out and "mm_token_type_ids" in out
     assert torch.equal(out["token_type_ids"], torch.zeros_like(out["input_ids"]))
     assert torch.equal(out["mm_token_type_ids"], torch.zeros_like(out["input_ids"]))
+
+
+def test_audiovisual_collator_batch_passes_per_sample_audio_and_images(tmp_path):
+    proc = DummyAudioVisualProcessor()
+    collator = DataCollatorGemmaAudioVisual(
+        processor=proc,
+        text_column="text",
+        family=GemmaFamily.GEMMA_4,
+        image_path_column="image_path",
+    )
+    paths = []
+    for i in range(3):
+        p = tmp_path / f"av_{i}.png"
+        PILImage.new("RGB", (8, 8), color=(0, 0, i * 80)).save(p)
+        paths.append(str(p))
+
+    import gemma_tuner.utils.dataset_prep as dataset_prep_mod
+
+    def fake_loader(path, sampling_rate=None):
+        return [0.0] * 16000
+
+    dataset_prep_mod.load_audio_local_or_gcs = fake_loader
+
+    collator(
+        [
+            {"audio_path": f"/path/{i}.wav", "image_path": paths[i], "text": f"sample {i}"}
+            for i in range(3)
+        ]
+    )
+    # Per-sample audio is a flat list of length batch; images is a list-per-sample wrapping.
+    assert isinstance(proc.last_audio, list) and len(proc.last_audio) == 3
+    assert isinstance(proc.last_images, list) and len(proc.last_images) == 3
+    for inner in proc.last_images:
+        assert isinstance(inner, list) and len(inner) == 1
+    assert isinstance(proc.last_text, list) and len(proc.last_text) == 3
+
+
+def test_audiovisual_collator_missing_audio_path_raises(tmp_path):
+    proc = DummyAudioVisualProcessor()
+    collator = DataCollatorGemmaAudioVisual(
+        processor=proc,
+        text_column="text",
+        family=GemmaFamily.GEMMA_4,
+        image_path_column="image_path",
+    )
+    p = tmp_path / "x.png"
+    PILImage.new("RGB", (8, 8), color=(1, 2, 3)).save(p)
+
+    import gemma_tuner.utils.dataset_prep as dataset_prep_mod
+
+    def fake_loader(path, sampling_rate=None):
+        return [0.0] * 16000
+
+    dataset_prep_mod.load_audio_local_or_gcs = fake_loader
+
+    with pytest.raises(KeyError, match=r"no audio path"):
+        collator([{"image_path": str(p), "text": "no audio key here"}])

--- a/tests/test_gemma_collator.py
+++ b/tests/test_gemma_collator.py
@@ -1,6 +1,7 @@
 import torch
+from PIL import Image as PILImage
 
-from gemma_tuner.models.common.collators import DataCollatorGemmaAudio
+from gemma_tuner.models.common.collators import DataCollatorGemmaAudio, DataCollatorGemmaAudioVisual
 from gemma_tuner.models.gemma.constants import GemmaTrainingConstants
 from gemma_tuner.models.gemma.family import GemmaFamily
 
@@ -87,6 +88,39 @@ def test_audio_collator_gemma4_injects_mm_token_type_ids():
     dataset_prep_mod.load_audio_local_or_gcs = fake_loader
 
     out = collator([{"audio_path": "/path/a.wav", "text": "hello"}])
+    assert "token_type_ids" in out and "mm_token_type_ids" in out
+    assert torch.equal(out["token_type_ids"], torch.zeros_like(out["input_ids"]))
+    assert torch.equal(out["mm_token_type_ids"], torch.zeros_like(out["input_ids"]))
+
+
+class DummyAudioVisualProcessor(DummyProcessor):
+    def __call__(self, text=None, audio=None, images=None, return_tensors=None, padding=None, **kwargs):
+        if audio is None or images is None:
+            raise ValueError("expected both audio and images")
+        return super().__call__(text=text, return_tensors=return_tensors, padding=padding, **kwargs)
+
+
+def test_audiovisual_collator_produces_labels_and_ids(tmp_path):
+    proc = DummyAudioVisualProcessor()
+    collator = DataCollatorGemmaAudioVisual(
+        processor=proc,
+        text_column="text",
+        family=GemmaFamily.GEMMA_4,
+        image_path_column="image_path",
+    )
+    image_path = tmp_path / "sample.png"
+    PILImage.new("RGB", (8, 8), color=(255, 0, 0)).save(image_path)
+
+    import gemma_tuner.utils.dataset_prep as dataset_prep_mod
+
+    def fake_loader(path, sampling_rate=None):
+        return [0.0] * 16000
+
+    dataset_prep_mod.load_audio_local_or_gcs = fake_loader
+
+    out = collator([{"audio_path": "/path/a.wav", "image_path": str(image_path), "text": "scene: people talking in a kitchen"}])
+    assert "input_ids" in out and "attention_mask" in out and "labels" in out
+    assert out["labels"].shape == out["input_ids"].shape
     assert "token_type_ids" in out and "mm_token_type_ids" in out
     assert torch.equal(out["token_type_ids"], torch.zeros_like(out["input_ids"]))
     assert torch.equal(out["mm_token_type_ids"], torch.zeros_like(out["input_ids"]))

--- a/tests/test_gemma_image_collator.py
+++ b/tests/test_gemma_image_collator.py
@@ -241,6 +241,43 @@ def test_apply_image_token_budget_warns_once_per_processor_type(caplog):
     assert len(records) == 1
 
 
+class _CapturingImageProcessor(FakeImageProcessor):
+    """Records the ``images`` kwarg shape passed to ``__call__`` for assertion."""
+
+    def __init__(self):
+        super().__init__()
+        self.last_images = None
+
+    def __call__(self, text=None, images=None, return_tensors=None, padding=None, **kwargs):
+        self.last_images = images
+        return super().__call__(text=text, images=images, return_tensors=return_tensors, padding=padding, **kwargs)
+
+
+def test_image_collator_passes_list_per_sample_to_processor(tmp_path: Path):
+    """Gemma 4 multimodal processor expects ``images`` as one list per text sample.
+
+    Regression for PR #22: collator wraps each PIL image as ``[img]`` so batched calls
+    keep the per-sample boundary intact.
+    """
+    proc = _CapturingImageProcessor()
+    collator = DataCollatorGemmaImage(
+        processor=proc,
+        text_column="caption",
+        family=GemmaFamily.GEMMA_3N,
+        image_path_column="image_path",
+        sub_mode="caption",
+    )
+    paths = []
+    for i in range(3):
+        p = tmp_path / f"b_{i}.png"
+        p.write_bytes(_make_png_bytes("RGB"))
+        paths.append(str(p))
+    collator([{"id": str(i), "image_path": paths[i], "caption": "x"} for i in range(3)])
+    assert isinstance(proc.last_images, list) and len(proc.last_images) == 3
+    for inner in proc.last_images:
+        assert isinstance(inner, list) and len(inner) == 1
+
+
 def test_image_collator_masks_padding_via_attention_mask_only(tmp_path: Path):
     """Padding is masked with attention_mask == 0 (not pad_id equality)."""
     proc = FakeImageProcessor()


### PR DESCRIPTION
Supersedes #22 by @alaaobeid, with follow-up fixes from a Musk-style audit.

## What's in this PR

Original work from #22 — adds `modality=audiovisual` (joint image + audio + text in one training run), wires `DataCollatorGemmaAudioVisual`, fixes batched-images shape in `DataCollatorGemmaImage`, validates the new modality end-to-end through config + dataset utils + finetune.

Follow-up fixes on top:

- **Reject `image_sub_mode=vqa` for `modality=audiovisual`** at config validation. The audiovisual collator hardcodes a caption-style instruction and ignores `prompt_column`; the old path let users silently get captioning when they asked for VQA. Fail loud at config time instead.
- **Regression test** for the `DataCollatorGemmaImage` batched-images change so the per-sample wrapping doesn't quietly regress.
- **Batch>1 test and missing-`audio_path` test** for `DataCollatorGemmaAudioVisual`.
- **README/Datasets.md** documents `modality=audiovisual` with a worked profile example.
- **Docstring** on `DataCollatorGemmaAudioVisual` explaining the audio-style label-builder choice (Gemma audio processor may set labels itself).

## Gates run locally

- `uv run ruff check gemma_tuner tests` — clean
- `uv run pytest` — 207 passed, 3 skipped. One pre-existing failure on `tests/test_granary.py::test_prepare_granary_basic_workflow` (test pollution / missing `config.ini` in CWD) reproduces on bare `main` and bare #22 — unrelated.

## Test plan

- [x] Ruff clean
- [x] Pytest green (except pre-existing granary test)
- [x] Audiovisual happy-path, batch>1, missing-audio_path, VQA-reject covered
- [x] Image collator batch>1 shape regression test added

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)