### PR TITLE
Surface 16 GB Mac memory-budget knobs in config example

### DIFF
--- a/README/KNOWN_ISSUES.md
+++ b/README/KNOWN_ISSUES.md
@@ -23,10 +23,11 @@
 
 ### Common MPS Errors and Solutions
 
-1. **"MPS backend out of memory"**
-   - Solution: Reduce batch size or set `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.7`
+1. **"MPS backend out of memory"** (or process killed with exit code `-9` + "leaked semaphore objects")
+   - On 16 GB Macs the stock defaults are over-budget. See the **16 GB Mac memory-budget knobs** block at the top of `config/config.ini.example` for the recommended profile overrides (`per_device_train_batch_size = 1`, `gradient_accumulation_steps = 16`, `gradient_checkpointing = true`, `bf16 = true`, `max_seq_length = 1024`).
+   - Solution: Reduce batch size or set `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.85`
    - With Flash Attention 2 enabled, memory usage drops ~28%, often eliminating OOMs
-   - The unified memory architecture can cause swapping instead of OOM errors
+   - The unified memory architecture can cause swapping instead of OOM errors, which macOS resolves by jetsam-killing the process — that's the source of the `-9` exit code.
 
 2. **"Operation X not implemented for MPS"**
    - Solution: Set `PYTORCH_ENABLE_MPS_FALLBACK=1` (performance impact)

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -122,6 +122,29 @@ lora_dropout = 0.05
 target_modules = q_proj,k_proj,v_proj,o_proj
 
 # ----------------------------------------------------------------------------
+# 16 GB Mac memory-budget knobs
+# ----------------------------------------------------------------------------
+# Stock defaults assume 32 GB+ unified memory. On 16 GB Macs the model + KV cache
+# + optimizer state usually doesn't fit, and macOS jetsam-kills the process
+# (you'll see "MPS backend out of memory" or exit code -9 with "leaked
+# semaphore objects"). Add these to your [profile:...] block on a 16 GB Mac:
+#
+#     per_device_train_batch_size = 1
+#     per_device_eval_batch_size = 1
+#     gradient_accumulation_steps = 16
+#     gradient_checkpointing = true
+#     bf16 = true
+#     max_seq_length = 1024            # drop to 512 if still OOM
+#     # image / audiovisual modalities:
+#     # image_token_budget = 70
+#
+# Also: use gemma-4-e2b(-it), not e4b. If MPS still complains, try
+#     export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.85
+# (do NOT set this to 0.0 — bootstrap rejects it).
+# See README/guides/apple-silicon/gemma4-guide.md for the full table.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
 # Template LoRA profile + dataset (edit and rename for your own data).
 # ----------------------------------------------------------------------------
 [profile:my-lora-run]


### PR DESCRIPTION
## Summary

- The stock defaults assume 32 GB+ unified memory. On 16 GB Macs users hit either "MPS backend out of memory" or SIGKILL (exit code -9 + leaked-semaphore warning, the macOS jetsam fingerprint).
- The fix table existed in \`README/guides/apple-silicon/gemma4-guide.md\` but was buried. Surfacing it directly above the template profile in \`config/config.ini.example\` and cross-referencing from \`README/KNOWN_ISSUES.md\`.

Closes #18. Refs #19, #21.

## Test plan

- [x] Visual inspection of \`config/config.ini.example\` — knob block reads cleanly above the template profile.
- [x] \`README/KNOWN_ISSUES.md\` "MPS backend out of memory" entry now points at the new block and mentions the \`-9\` symptom.
- No code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)