### PR TITLE
Apply ruff format to follow-up files from PR #23

### DIFF
--- a/gemma_tuner/core/config.py
+++ b/gemma_tuner/core/config.py
@@ -696,9 +696,7 @@ def _validate_profile_config(conf: Dict, required_keys: list[str]) -> None:
         if ims == "vqa" and modality_val == "image":
             pc = conf.get("prompt_column")
             if pc is None or (isinstance(pc, str) and not str(pc).strip()):
-                raise ValueError(
-                    "modality=image with image_sub_mode=vqa requires prompt_column (question column)"
-                )
+                raise ValueError("modality=image with image_sub_mode=vqa requires prompt_column (question column)")
 
     # Validate data splits are specified
     for split_key in ("train_split", "validation_split"):

--- a/tests/test_gemma_collator.py
+++ b/tests/test_gemma_collator.py
@@ -128,7 +128,9 @@ def test_audiovisual_collator_produces_labels_and_ids(tmp_path):
 
     dataset_prep_mod.load_audio_local_or_gcs = fake_loader
 
-    out = collator([{"audio_path": "/path/a.wav", "image_path": str(image_path), "text": "scene: people talking in a kitchen"}])
+    out = collator(
+        [{"audio_path": "/path/a.wav", "image_path": str(image_path), "text": "scene: people talking in a kitchen"}]
+    )
     assert "input_ids" in out and "attention_mask" in out and "labels" in out
     assert out["labels"].shape == out["input_ids"].shape
     assert "token_type_ids" in out and "mm_token_type_ids" in out
@@ -157,12 +159,7 @@ def test_audiovisual_collator_batch_passes_per_sample_audio_and_images(tmp_path)
 
     dataset_prep_mod.load_audio_local_or_gcs = fake_loader
 
-    collator(
-        [
-            {"audio_path": f"/path/{i}.wav", "image_path": paths[i], "text": f"sample {i}"}
-            for i in range(3)
-        ]
-    )
+    collator([{"audio_path": f"/path/{i}.wav", "image_path": paths[i], "text": f"sample {i}"} for i in range(3)])
     # Per-sample audio is a flat list of length batch; images is a list-per-sample wrapping.
     assert isinstance(proc.last_audio, list) and len(proc.last_audio) == 3
     assert isinstance(proc.last_images, list) and len(proc.last_images) == 3


### PR DESCRIPTION
## Summary

- \`ruff format --check\` flags two files touched by PR #23 (\`gemma_tuner/core/config.py\`, \`tests/test_gemma_collator.py\`). \`ruff check\` was clean, but the format gate wasn't.
- Mechanical fix only. No behavior change.

Surfaced while running the audit-fix loop on the audiovisual PRs.

## Test plan

- [x] \`uv run ruff format --check gemma_tuner tests\` — clean
- [x] \`uv run ruff check gemma_tuner tests\` — clean
- [x] \`uv run pytest tests/test_config.py tests/test_gemma_collator.py tests/test_gemma_image_collator.py\` — 36/36 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)